### PR TITLE
Fix rounded corners for tables with only the thead element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vui-table",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Mixins and CSS for applying table styles",
   "scripts": {
     "autoprefix": "postcss -c postcss.config.json",

--- a/table.scss
+++ b/table.scss
@@ -78,14 +78,16 @@
 	  colgroup:first-child + tfoot + tbody:last-child > tr:first-child > :last-child {
 		@include vui-table-top-border-radius('right');
 	}
-	& tfoot > tr:last-child > :first-child,
+	& thead:only-child > tr:last-child > :first-child,
+	  tfoot > tr:last-child > :first-child,
 	  tbody:only-child > tr:last-child > :first-child,
 	  thead + tbody:last-child > tr:last-child > :first-child,
 	  caption + tbody:last-child > tr:last-child > :first-child,
 	  colgroup + tbody:last-child > tr:last-child > :first-child {
 		@include vui-table-bottom-border-radius('left');
 	}
-	& tfoot > tr:last-child > :last-child,
+	& thead:only-child > tr:last-child > :last-child,
+	  tfoot > tr:last-child > :last-child,
 	  tbody:only-child > tr:last-child > :last-child,
 	  thead + tbody:last-child > tr:last-child > :last-child,
 	  caption + tbody:last-child > tr:last-child > :last-child,
@@ -93,8 +95,9 @@
 		@include vui-table-bottom-border-radius('right');
 	}
 
-	& tfoot tr:last-child th,
-	  tbody:last-child>tr:last-child>th {
+	& thead:only-child > tr:last-child th,
+	  tfoot tr:last-child th,
+	  tbody:last-child > tr:last-child > th {
 			border-bottom: none;
 	}
 

--- a/test/table.html
+++ b/test/table.html
@@ -132,6 +132,20 @@
 				</tr>
 			</tbody>
 		</table>
+
+		<p>Table setup - thead only</p>
+		<table class="vui-table">
+			<thead>
+				<tr>
+					<th class="vui-table-col-sort-asc">First Name</th>
+					<th class="vui-table-col-sort-desc">Last Name</th>
+					<th>Independent Assignments</th>
+					<th>Quizzes</th>
+					<th>Final Calculated Grade</th>
+				</tr>
+			</thead>
+		</table>
+
 	</div>
 	<div class="container on">
 		<h2>Mixins</h2>

--- a/test/table.rtl.html
+++ b/test/table.rtl.html
@@ -132,6 +132,19 @@
 				</tr>
 			</tbody>
 		</table>
+
+		<p>Table setup - thead only</p>
+		<table class="vui-table">
+			<thead>
+				<tr>
+					<th class="vui-table-col-sort-asc">First Name</th>
+					<th class="vui-table-col-sort-desc">Last Name</th>
+					<th>Independent Assignments</th>
+					<th>Quizzes</th>
+					<th>Final Calculated Grade</th>
+				</tr>
+			</thead>
+		</table>
 	</div>
 	<div class="container on">
 		<h2>Mixins</h2>


### PR DESCRIPTION
The bottom rounded corners were not being applied when a table only has the thead element.